### PR TITLE
Implemented Paper API patch 0179.

### DIFF
--- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
@@ -25,7 +25,7 @@ public interface Messenger {
     /**
      * Represents the largest size that a Plugin Channel may be.
      */
-    public static final int MAX_CHANNEL_SIZE = 64;
+    public static final int MAX_CHANNEL_SIZE = Integer.getInteger("paper.maxCustomChannelName", 64);
 
     /**
      * Checks if the specified channel is a reserved name.


### PR DESCRIPTION
Fixed "Better Furnaces Reforged" mod error while joining server.  
(It was registered a 78-chars-length plugin message channel name).