### PR TITLE
Add Velocity support (Paper server patch 0857)

### DIFF
--- a/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+++ b/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
@@ -1,0 +1,75 @@
+package com.destroystokyo.paper.proxy;
+
+import com.google.common.net.InetAddresses;
+import com.mohistmc.banner.config.BannerConfig;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.ProfilePublicKey;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.InetAddress;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+public class VelocityProxy {
+    private static final int SUPPORTED_FORWARDING_VERSION = 1;
+    public static final int MODERN_FORWARDING_WITH_KEY = 2;
+    public static final int MODERN_FORWARDING_WITH_KEY_V2 = 3;
+    public static final int MODERN_LAZY_SESSION = 4;
+    public static final byte MAX_SUPPORTED_FORWARDING_VERSION = MODERN_LAZY_SESSION;
+    public static final ResourceLocation PLAYER_INFO_CHANNEL = new ResourceLocation("velocity", "player_info");
+
+    public static boolean checkIntegrity(final FriendlyByteBuf buf) {
+        final byte[] signature = new byte[32];
+        buf.readBytes(signature);
+
+        final byte[] data = new byte[buf.readableBytes()];
+        buf.getBytes(buf.readerIndex(), data);
+
+        try {
+            final Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(BannerConfig.velocitySecret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
+            final byte[] mySignature = mac.doFinal(data);
+            if (!MessageDigest.isEqual(signature, mySignature)) {
+                return false;
+            }
+        } catch (final InvalidKeyException | NoSuchAlgorithmException e) {
+            throw new AssertionError(e);
+        }
+
+        return true;
+    }
+
+    public static InetAddress readAddress(final FriendlyByteBuf buf) {
+        return InetAddresses.forString(buf.readUtf(Short.MAX_VALUE));
+    }
+
+    public static GameProfile createProfile(final FriendlyByteBuf buf) {
+        final GameProfile profile = new GameProfile(buf.readUUID(), buf.readUtf(16));
+        readProperties(buf, profile);
+        return profile;
+    }
+
+    private static void readProperties(final FriendlyByteBuf buf, final GameProfile profile) {
+        final int properties = buf.readVarInt();
+        for (int i1 = 0; i1 < properties; i1++) {
+            final String name = buf.readUtf(Short.MAX_VALUE);
+            final String value = buf.readUtf(Short.MAX_VALUE);
+            final String signature = buf.readBoolean() ? buf.readUtf(Short.MAX_VALUE) : null;
+            profile.getProperties().put(name, new Property(name, value, signature));
+        }
+    }
+
+    public static ProfilePublicKey.Data readForwardedKey(FriendlyByteBuf buf) {
+        return new ProfilePublicKey.Data(buf);
+    }
+
+    public static UUID readSignerUuidOrElse(FriendlyByteBuf buf, UUID orElse) {
+        return buf.readBoolean() ? buf.readUUID() : orElse;
+    }
+}

--- a/src/main/java/com/mohistmc/banner/config/BannerConfig.java
+++ b/src/main/java/com/mohistmc/banner/config/BannerConfig.java
@@ -139,6 +139,9 @@ public class BannerConfig {
     public static String motdFirstLine;
     public static String motdSecondLine;
 
+    public static boolean velocityEnabled;
+    public static String velocitySecret;
+
     private static void banner() {
         check_update = getBoolean("banner.check_update", false);
         check_libraries = getBoolean("banner.check_libraries", true);
@@ -158,5 +161,7 @@ public class BannerConfig {
         clear_item__time = getInt("entity.clear.item.time", 1800);
         motdFirstLine = ColorsAPI.of(getString("motd.firstline", "<RAINBOW1>A Minecraft Server</RAINBOW>"));
         motdFirstLine = ColorsAPI.of(getString("motd.secondline", ""));
+        velocityEnabled = getBoolean("proxies.velocity.enabled", false);
+        velocitySecret = getString("proxies.velocity.secret", "");
     }
 }


### PR DESCRIPTION
把 Paper 的 Velocity 支持移植到 Banner （FabricProxy-Lite 设计没考虑到 Spigot 对登录部分的 patch ，改起来比较麻烦，所以实现了这个，即 Paper Server Patch 0857）。  
由于还没有实现 Paper 的配置文件，所以暂且把 Velocity 的相关配置放到 banner.yml 里面了。  
目前在自己的服务器上测试可以用。