### PR TITLE
Update MixinClipContext.java

### DIFF
--- a/src/main/java/com/mohistmc/banner/mixin/world/level/MixinClipContext.java
+++ b/src/main/java/com/mohistmc/banner/mixin/world/level/MixinClipContext.java
@@ -5,14 +5,17 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(value = ClipContext.class, priority = 900)
 public class MixinClipContext {
 
-    @Redirect(method = "<init>", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/world/phys/shapes/CollisionContext;of(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/shapes/CollisionContext;"))
-    private CollisionContext banner$resetClipContext(Entity entity) {
-        return (entity == null) ? CollisionContext.empty() : CollisionContext.of(entity); // CraftBukkit;
+    @ModifyArgs(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/shapes/CollisionContext;of(Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/phys/shapes/CollisionContext;"))
+    private void modifyArgs(Args args) {
+        Entity entity = (Entity) args.get(0);
+        if (entity == null) {
+            args.set(0, CollisionContext.empty());
+        }
     }
 }


### PR DESCRIPTION
### Modify details
- Changed from `@Redirect` to `@ModifyArgs`, shifting from redirecting the method invocation to modifying the arguments passed to it.
- Previously, the logic used `@Redirect` to intercept the call to `CollisionContext.of(Entity)` and replace it with custom behavior, but now with `@ModifyArgs`, we only change the argument passed to `CollisionContext.of(Entity)`, modifying it to `CollisionContext.empty()` if the `Entity` is `null`, otherwise leaving the original argument unchanged.  

### Why?[issues](https://github.com/MohistMC/Banner/issues/319)
  
- **Mixin Conflict**: A conflict arose between this Mixin and the `ClipContextMixin` from `porting_lib_base`, where both were attempting to use `@Redirect` on the same method invocation. By switching to `@ModifyArgs`, we avoid a full method redirection and only modify the argument, resolving the conflict.

### Expected Outcome

- This modification prevents the conflict caused by `@Redirect`, ensuring that the argument passed to `CollisionContext.of(Entity)` is correctly modified when needed, while other Mixins can still function without interference.