### PR TITLE
Fix plugin remapping

### DIFF
--- a/banner-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/banner-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -2,6 +2,11 @@ package org.bukkit.plugin.java;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+import com.mohistmc.banner.bukkit.remapping.ClassLoaderRemapper;
+import com.mohistmc.banner.bukkit.remapping.GlobalClassRepo;
+import com.mohistmc.banner.bukkit.remapping.Remapper;
+import net.fabricmc.loader.api.FabricLoader;
 import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.SimplePluginManager;
@@ -18,11 +23,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.CodeSigner;
 import java.security.CodeSource;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -182,6 +183,26 @@ final class PluginClassLoader extends URLClassLoader {
                 }
 
                 classBytes = loader.server.getUnsafe().processClass(description, path, classBytes);
+                classBytes = this.getRemapper().remapClassFile(classBytes, GlobalClassRepo.INSTANCE);
+
+                // BluSpring: Dump loaded classes, for me to figure out what's going wrong with any files.
+                if (FabricLoader.getInstance().isDevelopmentEnvironment() || System.getProperty("banner.dumpLoadedClasses", "false").equals("true")) {
+                    try {
+                        var file = new File(".banner/loaded/" + name.replace(".", "/") + ".class");
+
+                        if (!file.getParentFile().exists()) {
+                            file.getParentFile().mkdirs();
+                        }
+
+                        if (!file.exists()) {
+                            file.createNewFile();
+                        }
+
+                        Files.write(classBytes, file);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
 
                 int dot = name.lastIndexOf('.');
                 if (dot != -1) {
@@ -216,6 +237,16 @@ final class PluginClassLoader extends URLClassLoader {
         }
 
         return result;
+    }
+
+    private ClassLoaderRemapper remapper;
+
+    private ClassLoaderRemapper getRemapper() {
+        if (remapper == null) {
+            remapper = Remapper.createClassLoaderRemapper(this);
+        }
+
+        return remapper;
     }
 
     @Override

--- a/banner-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/banner-api/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -6,7 +6,6 @@ import com.google.common.io.Files;
 import com.mohistmc.banner.bukkit.remapping.ClassLoaderRemapper;
 import com.mohistmc.banner.bukkit.remapping.GlobalClassRepo;
 import com.mohistmc.banner.bukkit.remapping.Remapper;
-import net.fabricmc.loader.api.FabricLoader;
 import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.SimplePluginManager;
@@ -185,8 +184,8 @@ final class PluginClassLoader extends URLClassLoader {
                 classBytes = loader.server.getUnsafe().processClass(description, path, classBytes);
                 classBytes = this.getRemapper().remapClassFile(classBytes, GlobalClassRepo.INSTANCE);
 
-                // BluSpring: Dump loaded classes, for me to figure out what's going wrong with any files.
-                if (FabricLoader.getInstance().isDevelopmentEnvironment() || System.getProperty("banner.dumpLoadedClasses", "false").equals("true")) {
+                // Banner: Allow dumping of loaded classes, to help figure out what's going wrong with any files.
+                if (System.getProperty("banner.dumpLoadedClasses", "false").equals("true")) {
                     try {
                         var file = new File(".banner/loaded/" + name.replace(".", "/") + ".class");
 


### PR DESCRIPTION
Fixes plugin remapping from Bukkit NMS mappings to Intermediary/Mojang (depending on the environment).
This in turn fixes AnimatedScoreboards using the legacy Bukkit implementation instead of the packet implementation.